### PR TITLE
Preparacao para a versao 5.1.17

### DIFF
--- a/sermil-core/pom.xml
+++ b/sermil-core/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.mil.eb.sermil</groupId>
   <artifactId>sermil-core</artifactId>
-  <version>5.1.16</version>
+  <version>5.1.17</version>
   <name>SERMIL CORE</name>
   <description>SERMIL CORE SERVICES</description>
   <dependencies>


### PR DESCRIPTION
Precisei fazer isso porque por engano mandei a versao 5.1.16 para o Citex.
Entao agora a situacao esta assim:
Versao 5.1.15 - no servidor novo aguardando liberacao
Versao 5.1.16 - enviada para entrar em producao no servidor antigo que ainda ta funcionando
Versao 5.1.17 - é a  versao na qual estamos trabalhando agora.